### PR TITLE
feat : global yearly chart DAG 추가

### DIFF
--- a/dags/config/country_weekly_chart.py
+++ b/dags/config/country_weekly_chart.py
@@ -2,20 +2,6 @@
     'schema': 'raw',
     'table': 'country_weekly_chart',
     'sqls' : {
-        'test_sql' : """
-            SELECT 
-                $1 AS rank, 
-                $2 AS track_id, 
-                $3 AS artist_names, 
-                $4 AS track_name, 
-                $5 AS peak_rank, 
-                $6 AS previous_rank, 
-                $7 AS weeks_on_chart, 
-                $8 AS streams, 
-                $9 AS country_code, 
-                $10 AS chart_date
-            FROM @raw.transformed_data_stage_csv/spotify/chart/{date}/{target_file_pattern};
-    """ ,
         'load_sql' : """
                         BEGIN;
 
@@ -46,7 +32,7 @@
     'dag_params':{
         'table_name':'country_weekly_chart',
         'source_file_pattern' : 'regional-*-weekly-{date}.csv',
-        'target_file_pattern' : 'country-weekly-{date}.csv',       
+        'target_file_pattern' : 'country-weekly-{date}.csv'  
     }
          
 }

--- a/dags/config/global_yearly_chart.py
+++ b/dags/config/global_yearly_chart.py
@@ -1,6 +1,6 @@
 {
     'schema': 'raw',
-    'table': 'global_weekly_chart',
+    'table': 'global_yearly_chart',
     'sqls' : {
         'load_sql' : """
                         BEGIN;
@@ -15,13 +15,14 @@
                             $6 AS previous_rank, 
                             $7 AS weeks_on_chart, 
                             $8 AS streams, 
-                            $9 AS chart_date
+                            to_timestamp(to_char(to_date($9, 'yyyy-mm-dd'), 'yyyy-mm-dd')) AS chart_date,
+                            $10 AS days_on_chart
                         FROM @raw.transformed_data_stage_csv/spotify/chart/{date}/{target_file_pattern};
                         
-                        DELETE FROM raw.global_weekly_chart
+                        DELETE FROM raw.global_yearly_chart
                         WHERE chart_date = '{date}';
 
-                        INSERT INTO raw.global_weekly_chart
+                        INSERT INTO raw.global_yearly_chart
                         SELECT t.* 
                         FROM temp_table t;
 
@@ -29,8 +30,8 @@
                     """
     },
     'dag_params':{
-        'table_name':'global_weekly_chart',
-        'source_file_pattern' : 'regional-global-weekly-{date}.csv',
-        'target_file_pattern' : 'global-weekly-{date}.csv'  
+        'table_name':'global_yearly_chart',
+        'source_file_pattern' : 'regional-global-daily-{date}.csv',
+        'target_file_pattern' : 'global-yearly-{date}.csv'
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#42 -> main

### 변경 사항
* global yearly chart DAG를 추가했습니다.
기존 global yearly chart data 가 6년간 매월 1일의 차트데이터를 가져오고 있어, 매월 1일에 한달 간격으로 실행되게 설정했습니다.

### 테스트 결과
5/1, 6/1 데이터 적재 확인하였습니다.
<img width="1041" alt="image" src="https://github.com/data-engineering-team4/kpop_dashboard/assets/103317018/742d8071-c64d-444d-b5df-aee8ac494bbf">


