### PR TITLE
Docker ci test

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,12 +6,6 @@ on:
     paths:
       - 'dags/**'
       - 'dbt/**'
-  pull_request:
-    branches: [ "main" ]
-    paths:
-      - 'dags/**'
-      - 'dbt/**'
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +20,7 @@ jobs:
       uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and push
       uses: docker/build-push-action@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v2 
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,39 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'dags/**'
+      - 'dbt/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'dags/**'
+      - 'dbt/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: kpopdocker/kpop-airflow:latest
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM apache/airflow:2.6.2
-
-COPY requirements.txt /
-
 USER airflow
-
+COPY requirements.txt /
 RUN pip install --no-cache-dir -r /requirements.txt
+COPY --chown=airflow:root dags /opt/airflow/dags
+COPY dbt /dbt
+
+

--- a/dags/delete_log_dag.py
+++ b/dags/delete_log_dag.py
@@ -1,0 +1,42 @@
+"""30일 지난 Airflow 로그를 삭제함
+    
+    사용 명령어 : find [airflow log dir] -type f -mtime +30 -delete
+        : ex. find /opt/airflow/logs -type f -mtime +30 -delete
+        : 위에 명령어를 BashOperator로 실행
+
+    옵션 설명 : 
+        : -type f : 일반 파일만 검색
+            * 추가 설명 :  d: 디렉토리, l: 링크 파일, b: 블록디바이스, c: 캐릭터 디바이스 ...
+        : -mtime +30 : 생성한지 720시간 이상 지난 파일만 검색
+        : -delete : 삭제
+"""
+import pendulum
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.bash import BashOperator # Import BashOperator
+
+"""Set DAG"""
+KST_TZ = pendulum.timezone("Asia/Seoul")
+
+default_args = {
+    'owner': 'kpop',
+    'retries': 3,
+    'retry_delay': timedelta(minutes=10)
+}
+
+with DAG(
+    dag_id='delete_logs_mtime_30', 
+    default_args=default_args,
+    start_date=datetime(2023, 7, 1, tzinfo=KST_TZ), 
+    catchup=False, 
+    schedule_interval='* 2 * * *',  # Crontime : min hour day month week / 매일 02시에 삭제
+    max_active_runs=3,
+    tags=['operation']
+) as dag:
+
+    delete_logs = BashOperator(
+        task_id='delete_logs',
+        bash_command='find /opt/airflow/logs -type f -mtime +30 -delete'
+    )
+
+    delete_logs

--- a/dags/delete_log_dag.py
+++ b/dags/delete_log_dag.py
@@ -1,15 +1,3 @@
-"""30일 지난 Airflow 로그를 삭제함
-    
-    사용 명령어 : find [airflow log dir] -type f -mtime +30 -delete
-        : ex. find /opt/airflow/logs -type f -mtime +30 -delete
-        : 위에 명령어를 BashOperator로 실행
-
-    옵션 설명 : 
-        : -type f : 일반 파일만 검색
-            * 추가 설명 :  d: 디렉토리, l: 링크 파일, b: 블록디바이스, c: 캐릭터 디바이스 ...
-        : -mtime +30 : 생성한지 720시간 이상 지난 파일만 검색
-        : -delete : 삭제
-"""
 import pendulum
 from datetime import datetime, timedelta
 from airflow import DAG

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,8 +49,8 @@ x-airflow-common: &airflow-common
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-  #image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.6.2}
-  build: .
+  image: ${AIRFLOW_IMAGE_NAME:-kpopdocker/kpop-airflow:latest}
+  #build: .
   environment: &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
@@ -112,7 +112,7 @@ services:
     expose:
       - 6379
     ports:
-      - "6379:6379"  
+      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,7 +72,7 @@ x-airflow-common: &airflow-common
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
 
   volumes:
-    - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
+    # - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
docker-ci-test -> main

### 변경 사항
* DAG가 들어간 extended airflow image를 kpopdocker/kpop-airflow 이름으로 이미지 생성했습니다.
dockerhub : https://hub.docker.com/repository/docker/kpopdocker/kpop-airflow/general
* dag나 dbt 폴더의 파일이 main에 push 된다면 trigger되는 git action을 작성했습니다.
* log를 삭제하는 DAG를 추가했습니다.

### 테스트 결과
image push 된 것 확인했습니다.
<img width="863" alt="image" src="https://github.com/data-engineering-team4/kpop_dashboard/assets/103317018/061f6b84-8804-4486-af99-ac8626783e94">

### 참고 사항
docker_compose.yml에 dags 폴더가 매핑되어있어 image에 있는 dag들이 있어도 매핑되어있는 호스트 시스템 dags의 폴더에 있는 dag들과 동기화되어 dags폴더 매핑을 제거했습니다. 뭔가 docker_compose.yml 파일도 dev, prod 로 나눠야할 것 같습니다!